### PR TITLE
feat: generate graph from inline sql code

### DIFF
--- a/gen.sql/src/main/java/edu/pku/code2graph/gen/sql/JsqlGenerator.java
+++ b/gen.sql/src/main/java/edu/pku/code2graph/gen/sql/JsqlGenerator.java
@@ -32,6 +32,16 @@ public class JsqlGenerator extends Generator {
           }
         });
     GraphUtil.getUriMap().put(Language.SQL, hdl.getUriMap());
-    return null;
+    return hdl.getGraph();
+  }
+
+  public Graph<Node, Edge> generate(
+      String query, String filepath, Language lang, String identifier) {
+    StatementHandler hdl = new StatementHandler(true, lang, identifier);
+    Statements stmt = parser.parseLines(query);
+    hdl.setFilePath(filepath);
+    hdl.generateFrom(stmt);
+    GraphUtil.getUriMap().put(Language.SQL, hdl.getUriMap());
+    return hdl.getGraph();
   }
 }

--- a/gen.sql/src/main/java/edu/pku/code2graph/gen/sql/StatementHandler.java
+++ b/gen.sql/src/main/java/edu/pku/code2graph/gen/sql/StatementHandler.java
@@ -42,8 +42,20 @@ public class StatementHandler {
   protected Graph<Node, Edge> graph = GraphUtil.getGraph();
   protected Map<URI, ElementNode> uriMap = new HashMap<>();
 
+  private boolean isInline = false;
+  private Language wrapLang;
+  private String wrapIdentifier;
+
   // temporarily save the current file path here
   protected String filePath;
+
+  public StatementHandler() {}
+
+  public StatementHandler(boolean inline, Language lang, String identifier) {
+    this.isInline = inline;
+    this.wrapLang = lang;
+    this.wrapIdentifier = identifier;
+  }
 
   public void generateFrom(Statements stmts) {
     //    stmts.accept(deParser);
@@ -351,7 +363,13 @@ public class StatementHandler {
                               + "/"
                               + (URI.checkInvalidCh(columnDataType.getColumnName()));
                       URI uri = new URI(Protocol.ANY, Language.SQL, filePath, idtf);
-                      en.setUri(uri);
+                      if (isInline) {
+                        URI wrapUri = new URI(Protocol.ANY, wrapLang, filePath, wrapIdentifier);
+                        wrapUri.setInline(uri);
+                        en.setUri(wrapUri);
+                      } else {
+                        en.setUri(uri);
+                      }
                       uriMap.put(en.getUri(), en);
                       graph.addEdge(parent, en, new Edge(GraphUtil.eid(), CHILD));
                     });
@@ -501,7 +519,13 @@ public class StatementHandler {
     findParentEdge(snode, en);
 
     URI uri = new URI(Protocol.USE, Language.SQL, filePath, identifierMap.get(en));
-    en.setUri(uri);
+    if (isInline) {
+      URI wrapUri = new URI(Protocol.ANY, wrapLang, filePath, wrapIdentifier);
+      wrapUri.setInline(uri);
+      en.setUri(wrapUri);
+    } else {
+      en.setUri(uri);
+    }
     uriMap.put(en.getUri(), en);
   }
 

--- a/gen.sql/src/test/java/HandlerTest.java
+++ b/gen.sql/src/test/java/HandlerTest.java
@@ -2,10 +2,7 @@ import edu.pku.code2graph.gen.sql.JsqlGenerator;
 import edu.pku.code2graph.gen.sql.SqlParser;
 import edu.pku.code2graph.gen.sql.StatementHandler;
 import edu.pku.code2graph.io.GraphVizExporter;
-import edu.pku.code2graph.model.Edge;
-import edu.pku.code2graph.model.ElementNode;
-import edu.pku.code2graph.model.Node;
-import edu.pku.code2graph.model.RelationNode;
+import edu.pku.code2graph.model.*;
 import edu.pku.code2graph.util.GraphUtil;
 import org.apache.log4j.BasicConfigurator;
 import org.apache.log4j.Level;
@@ -146,5 +143,33 @@ public class HandlerTest {
               }
             });
     assertThat(filePaths.size()).isEqualTo(inVertex.size());
+  }
+
+  @Test
+  public void testInline() {
+    JsqlGenerator generator = new JsqlGenerator();
+    GraphUtil.clearGraph();
+    String query = "SELECT * FROM Customers\n" + "WHERE Country='Germany' AND City='Berlin';";
+    String idtf = "Class/function/Select";
+    Language lang = Language.JAVA;
+    String filepath = "src/resources/test/what.java";
+    generator.generate(
+        query, filepath, lang, idtf);
+
+    List<ElementNode> countryNode = new ArrayList<>();
+    GraphUtil.getGraph()
+            .vertexSet()
+            .forEach(
+                    v -> {
+                      if (v instanceof ElementNode && ((ElementNode) v).getName().equals("Country")) {
+                        countryNode.add((ElementNode) v);
+                      }
+                    });
+    countryNode.forEach(node->{
+      assertThat(node.getUri().getIdentifier()).isEqualTo(idtf);
+      assertThat(node.getUri().getFile()).isEqualTo(filepath);
+      assertThat(node.getUri().getLang()).isEqualTo(lang);
+      assertThat(node.getUri().getInline().getIdentifier()).isEqualTo("Select/Where/=/Country");
+    });
   }
 }


### PR DESCRIPTION
API added: `public Graph<Node, Edge> generate(String query, String filepath, Language lang, String identifier)`

parameters `filepath`, `lang`, `identifier` are attributes of the parent element