### PR TITLE
refa: extract common parameter repoPath to field of *GitService

### DIFF
--- a/client/src/main/java/edu/pku/code2graph/client/Code2Graph.java
+++ b/client/src/main/java/edu/pku/code2graph/client/Code2Graph.java
@@ -2,6 +2,7 @@ package edu.pku.code2graph.client;
 
 import edu.pku.code2graph.diff.Differ;
 import edu.pku.code2graph.diff.model.ChangeType;
+import edu.pku.code2graph.exception.InvalidRepoException;
 import edu.pku.code2graph.exception.NonexistPathException;
 import edu.pku.code2graph.gen.Generator;
 import edu.pku.code2graph.gen.Generators;
@@ -109,7 +110,7 @@ public class Code2Graph {
       Differ differ = new Differ(repoName, repoPath, diffTempDir);
       differ.buildGraphs();
       differ.compareGraphs();
-    } catch (IOException e) {
+    } catch (NonexistPathException | InvalidRepoException | IOException e) {
       e.printStackTrace();
     }
   }
@@ -120,7 +121,7 @@ public class Code2Graph {
       Differ differ = new Differ(repoName, repoPath, diffTempDir);
       differ.buildGraphs(commitID);
       differ.compareGraphs();
-    } catch (IOException e) {
+    } catch (NonexistPathException | InvalidRepoException | IOException e) {
       e.printStackTrace();
     }
   }

--- a/client/src/main/java/edu/pku/code2graph/client/Evaluation.java
+++ b/client/src/main/java/edu/pku/code2graph/client/Evaluation.java
@@ -7,6 +7,7 @@ import edu.pku.code2graph.diff.model.DiffFile;
 import edu.pku.code2graph.diff.util.GitService;
 import edu.pku.code2graph.diff.util.GitServiceCGit;
 import edu.pku.code2graph.diff.util.MetricUtil;
+import edu.pku.code2graph.exception.InvalidRepoException;
 import edu.pku.code2graph.exception.NonexistPathException;
 import edu.pku.code2graph.model.Edge;
 import edu.pku.code2graph.model.Language;
@@ -51,21 +52,23 @@ public class Evaluation {
   private static String gtPath = gtDir + "/" + repoName + ".csv";
   private static String otPath = gtPath.replace("groundtruth", "output");
 
-  private static Code2Graph c2g = null;
+  private static Code2Graph c2g;
   private static List<Link> xllLinks = new ArrayList<>();
 
-  private static GitService gitService = new GitServiceCGit(repoPath);
-  private static RepoAnalyzer repoAnalyzer = new RepoAnalyzer(repoName, repoPath);
+  private static GitService gitService;
+  private static RepoAnalyzer repoAnalyzer;
 
   public static void main(String[] args) {
     BasicConfigurator.configure();
     org.apache.log4j.Logger.getRootLogger().setLevel(Level.INFO);
 
     // set up
-    addCommitIdToPath();
-
     try {
+      gitService = new GitServiceCGit(repoPath);
+      repoAnalyzer = new RepoAnalyzer(repoName, repoPath);
       c2g = new Code2Graph(repoName, repoPath, configPath);
+
+      addCommitIdToPath();
       switch (framework) {
         case "springmvc":
           c2g.addSupportedLanguage(Language.JAVA);
@@ -95,7 +98,11 @@ public class Evaluation {
       // compare by solely loading csv files
       testXLLDetection();
       //            testCochange();
-    } catch (ParserConfigurationException | SAXException | NonexistPathException | IOException e) {
+    } catch (ParserConfigurationException
+        | SAXException
+        | NonexistPathException
+        | IOException
+        | InvalidRepoException e) {
       e.printStackTrace();
     }
   }

--- a/client/src/main/java/edu/pku/code2graph/client/Evaluation.java
+++ b/client/src/main/java/edu/pku/code2graph/client/Evaluation.java
@@ -54,7 +54,7 @@ public class Evaluation {
   private static Code2Graph c2g = null;
   private static List<Link> xllLinks = new ArrayList<>();
 
-  private static GitService gitService = new GitServiceCGit();
+  private static GitService gitService = new GitServiceCGit(repoPath);
   private static RepoAnalyzer repoAnalyzer = new RepoAnalyzer(repoName, repoPath);
 
   public static void main(String[] args) {
@@ -85,8 +85,7 @@ public class Evaluation {
           c2g.addSupportedLanguage(Language.JAVA);
       }
 
-      logger.info(
-          "Generating graph for repo {}:{}", repoName, gitService.getHEADCommitId(repoPath));
+      logger.info("Generating graph for repo {}:{}", repoName, gitService.getHEADCommitId());
       // for testXLLDetection, run once and save the output, then comment
       Graph<Node, Edge> graph = c2g.generateGraph();
       xllLinks = c2g.getXllLinks();
@@ -117,7 +116,7 @@ public class Evaluation {
 
     if (commitID != null) {
       otPath = gtPath.replace("groundtruth", "output");
-      if (!gitService.checkoutByCommitID(repoPath, commitID)) {
+      if (!gitService.checkoutByCommitID(commitID)) {
         logger.error("Failed to checkout to {}", commitID);
       } else {
         logger.info("Successfully checkout to {}", commitID);

--- a/client/src/main/java/edu/pku/code2graph/client/Evaluation.java
+++ b/client/src/main/java/edu/pku/code2graph/client/Evaluation.java
@@ -252,7 +252,7 @@ public class Evaluation {
       // get commits that changed the line range (range evolution history)
       List<String> commits =
           gitService.getCommitsChangedLineRange(
-              repoPath, link.left.getFile(), range.getStartLine(), range.getEndLine());
+              link.left.getFile(), range.getStartLine(), range.getEndLine());
 
       // extract the changed files in each commit
       for (String commit : commits) {

--- a/client/src/main/java/edu/pku/code2graph/client/WiseAdapt.java
+++ b/client/src/main/java/edu/pku/code2graph/client/WiseAdapt.java
@@ -2,13 +2,15 @@ package edu.pku.code2graph.client;
 
 import edu.pku.code2graph.diff.RepoAnalyzer;
 import edu.pku.code2graph.diff.model.DiffFile;
+import edu.pku.code2graph.exception.InvalidRepoException;
+import edu.pku.code2graph.exception.NonexistPathException;
 import org.apache.log4j.PropertyConfigurator;
 
 import java.util.List;
 
 public class WiseAdapt {
 
-  public static void main(String[] args) {
+  public static void main(String[] args) throws NonexistPathException, InvalidRepoException {
     PropertyConfigurator.configure("log4j.properties");
 
     // input commit id

--- a/client/src/main/java/edu/pku/code2graph/client/extractor/Extraction.java
+++ b/client/src/main/java/edu/pku/code2graph/client/extractor/Extraction.java
@@ -31,7 +31,7 @@ public class Extraction {
           + repoName
           + ".csv";
 
-  private static GitService gitService = new GitServiceCGit();
+  private static GitService gitService = new GitServiceCGit(repoPath);
 
   public static void main(String[] args)
       throws IOException, ParserConfigurationException, SAXException {
@@ -58,7 +58,7 @@ public class Extraction {
   }
 
   private static void addCommitIdToPath() {
-    String commitID = gitService.getHEADCommitId(repoPath);
+    String commitID = gitService.getHEADCommitId();
     if (commitID != null) {
       gtPath =
           System.getProperty("user.dir")

--- a/client/src/main/java/edu/pku/code2graph/client/extractor/Extraction.java
+++ b/client/src/main/java/edu/pku/code2graph/client/extractor/Extraction.java
@@ -3,6 +3,8 @@ package edu.pku.code2graph.client.extractor;
 import edu.pku.code2graph.client.Evaluation;
 import edu.pku.code2graph.diff.util.GitService;
 import edu.pku.code2graph.diff.util.GitServiceCGit;
+import edu.pku.code2graph.exception.InvalidRepoException;
+import edu.pku.code2graph.exception.NonexistPathException;
 import org.apache.log4j.BasicConfigurator;
 import org.apache.log4j.Level;
 import org.slf4j.Logger;
@@ -31,12 +33,18 @@ public class Extraction {
           + repoName
           + ".csv";
 
-  private static GitService gitService = new GitServiceCGit(repoPath);
+  private static GitService gitService;
 
   public static void main(String[] args)
       throws IOException, ParserConfigurationException, SAXException {
     BasicConfigurator.configure();
     org.apache.log4j.Logger.getRootLogger().setLevel(Level.INFO);
+
+    try {
+      gitService = new GitServiceCGit(repoPath);
+    } catch (NonexistPathException | IOException | InvalidRepoException e) {
+      e.printStackTrace();
+    }
 
     addCommitIdToPath();
 

--- a/core/src/main/java/edu/pku/code2graph/exception/InvalidRepoException.java
+++ b/core/src/main/java/edu/pku/code2graph/exception/InvalidRepoException.java
@@ -1,0 +1,20 @@
+package edu.pku.code2graph.exception;
+
+public class InvalidRepoException extends Exception {
+
+  public InvalidRepoException() {
+    super("Invalid Git repository.");
+  }
+
+  public InvalidRepoException(String message) {
+    super("Invalid Git repository: " + message);
+  }
+
+  public InvalidRepoException(String message, String repoPath) {
+    super(detailErrorMessage(message, repoPath));
+  }
+
+  private static String detailErrorMessage(String message, String repoPath) {
+    return repoPath + " is not a valid Git repository for " + message;
+  }
+}

--- a/core/src/main/java/edu/pku/code2graph/util/FileUtil.java
+++ b/core/src/main/java/edu/pku/code2graph/util/FileUtil.java
@@ -20,23 +20,6 @@ public class FileUtil {
     return (new File(path)).exists();
   }
 
-  public static boolean isSubDirectory(String childPath, String basePath) throws IOException {
-    File base = new File(basePath);
-    File child = new File(childPath);
-
-    base = base.getCanonicalFile();
-    child = child.getCanonicalFile();
-
-    File parentFile = child;
-    while (parentFile != null) {
-      if (base.equals(parentFile)) {
-        return true;
-      }
-      parentFile = parentFile.getParentFile();
-    }
-    return false;
-  }
-
   /**
    * Create a folder if not exists
    *

--- a/core/src/main/java/edu/pku/code2graph/util/FileUtil.java
+++ b/core/src/main/java/edu/pku/code2graph/util/FileUtil.java
@@ -20,6 +20,23 @@ public class FileUtil {
     return (new File(path)).exists();
   }
 
+  public static boolean isSubDirectory(String childPath, String basePath) throws IOException {
+    File base = new File(basePath);
+    File child = new File(childPath);
+
+    base = base.getCanonicalFile();
+    child = child.getCanonicalFile();
+
+    File parentFile = child;
+    while (parentFile != null) {
+      if (base.equals(parentFile)) {
+        return true;
+      }
+      parentFile = parentFile.getParentFile();
+    }
+    return false;
+  }
+
   /**
    * Create a folder if not exists
    *

--- a/diff/src/main/java/edu/pku/code2graph/diff/Differ.java
+++ b/diff/src/main/java/edu/pku/code2graph/diff/Differ.java
@@ -5,6 +5,8 @@ import edu.pku.code2graph.diff.model.DiffHunk;
 import edu.pku.code2graph.diff.model.Mapping;
 import edu.pku.code2graph.diff.model.Version;
 import edu.pku.code2graph.diff.util.MetricUtil;
+import edu.pku.code2graph.exception.InvalidRepoException;
+import edu.pku.code2graph.exception.NonexistPathException;
 import edu.pku.code2graph.gen.Generator;
 import edu.pku.code2graph.gen.Generators;
 import edu.pku.code2graph.gen.Register;
@@ -83,8 +85,7 @@ public class Differ {
   }
 
   /** Analyze changes in working directory */
-  public void buildGraphs() throws IOException {
-
+  public void buildGraphs() throws IOException, NonexistPathException, InvalidRepoException {
     RepoAnalyzer repoAnalyzer = new RepoAnalyzer(repoName, repoPath);
     diffFiles = repoAnalyzer.analyzeWorkingTree();
     diffHunks = repoAnalyzer.getDiffHunks();
@@ -117,7 +118,8 @@ public class Differ {
    *
    * @param commitID
    */
-  public void buildGraphs(String commitID) throws IOException {
+  public void buildGraphs(String commitID)
+      throws IOException, NonexistPathException, InvalidRepoException {
     if (commitID.isEmpty()) {
       // TODO check commit id validity and throw exception
       logger.error("Invalid commit id: " + commitID);

--- a/diff/src/main/java/edu/pku/code2graph/diff/RepoAnalyzer.java
+++ b/diff/src/main/java/edu/pku/code2graph/diff/RepoAnalyzer.java
@@ -4,7 +4,11 @@ import edu.pku.code2graph.diff.model.DiffFile;
 import edu.pku.code2graph.diff.model.DiffHunk;
 import edu.pku.code2graph.diff.util.GitService;
 import edu.pku.code2graph.diff.util.GitServiceCGit;
+import edu.pku.code2graph.exception.InvalidRepoException;
+import edu.pku.code2graph.exception.NonexistPathException;
+import edu.pku.code2graph.util.FileUtil;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -15,7 +19,11 @@ public class RepoAnalyzer {
   private List<DiffFile> diffFiles;
   private List<DiffHunk> diffHunks;
 
-  public RepoAnalyzer(String repoName, String repoPath) {
+  public RepoAnalyzer(String repoName, String repoPath)
+      throws NonexistPathException, InvalidRepoException {
+    if (!FileUtil.checkExists(repoPath)) {
+      throw new NonexistPathException("Repo", repoPath);
+    }
     this.repoName = repoName;
     this.repoPath = repoPath;
     this.diffFiles = new ArrayList<>();
@@ -29,12 +37,17 @@ public class RepoAnalyzer {
    */
   public List<DiffFile> analyzeWorkingTree() {
     // analyze the diff files and hunks
-    GitService gitService = new GitServiceCGit(repoPath);
-    ArrayList<DiffFile> diffFiles = gitService.getChangedFilesInWorkingTree();
-    if (!diffFiles.isEmpty()) {
-      this.diffHunks = gitService.getDiffHunksInWorkingTree(diffFiles);
-      this.diffFiles = diffFiles;
+    try {
+      GitService gitService = new GitServiceCGit(repoPath);
+      ArrayList<DiffFile> diffFiles = gitService.getChangedFilesInWorkingTree();
+      if (!diffFiles.isEmpty()) {
+        this.diffHunks = gitService.getDiffHunksInWorkingTree(diffFiles);
+        this.diffFiles = diffFiles;
+      }
+    } catch (NonexistPathException | IOException | InvalidRepoException e) {
+      e.printStackTrace();
     }
+
     return diffFiles;
   }
 
@@ -45,12 +58,16 @@ public class RepoAnalyzer {
    */
   public List<DiffFile> analyzeCommit(String commitID) {
     // analyze the diff files and hunks
-    GitServiceCGit gitService = new GitServiceCGit(repoPath);
-    gitService.setIgnoreWhiteChanges(true);
-    ArrayList<DiffFile> diffFiles = gitService.getChangedFilesAtCommit(commitID);
-    if (!diffFiles.isEmpty()) {
-      this.diffHunks = gitService.getDiffHunksAtCommit(commitID, diffFiles);
-      this.diffFiles = diffFiles;
+    try {
+      GitServiceCGit gitService = new GitServiceCGit(repoPath);
+      gitService.setIgnoreWhiteChanges(true);
+      ArrayList<DiffFile> diffFiles = gitService.getChangedFilesAtCommit(commitID);
+      if (!diffFiles.isEmpty()) {
+        this.diffHunks = gitService.getDiffHunksAtCommit(commitID, diffFiles);
+        this.diffFiles = diffFiles;
+      }
+    } catch (NonexistPathException | IOException | InvalidRepoException e) {
+      e.printStackTrace();
     }
     return diffFiles;
   }

--- a/diff/src/main/java/edu/pku/code2graph/diff/RepoAnalyzer.java
+++ b/diff/src/main/java/edu/pku/code2graph/diff/RepoAnalyzer.java
@@ -29,10 +29,10 @@ public class RepoAnalyzer {
    */
   public List<DiffFile> analyzeWorkingTree() {
     // analyze the diff files and hunks
-    GitService gitService = new GitServiceCGit();
-    ArrayList<DiffFile> diffFiles = gitService.getChangedFilesInWorkingTree(this.repoPath);
+    GitService gitService = new GitServiceCGit(repoPath);
+    ArrayList<DiffFile> diffFiles = gitService.getChangedFilesInWorkingTree();
     if (!diffFiles.isEmpty()) {
-      this.diffHunks = gitService.getDiffHunksInWorkingTree(this.repoPath, diffFiles);
+      this.diffHunks = gitService.getDiffHunksInWorkingTree(diffFiles);
       this.diffFiles = diffFiles;
     }
     return diffFiles;
@@ -45,11 +45,11 @@ public class RepoAnalyzer {
    */
   public List<DiffFile> analyzeCommit(String commitID) {
     // analyze the diff files and hunks
-    GitServiceCGit gitService = new GitServiceCGit();
+    GitServiceCGit gitService = new GitServiceCGit(repoPath);
     gitService.setIgnoreWhiteChanges(true);
-    ArrayList<DiffFile> diffFiles = gitService.getChangedFilesAtCommit(this.repoPath, commitID);
+    ArrayList<DiffFile> diffFiles = gitService.getChangedFilesAtCommit(commitID);
     if (!diffFiles.isEmpty()) {
-      this.diffHunks = gitService.getDiffHunksAtCommit(this.repoPath, commitID, diffFiles);
+      this.diffHunks = gitService.getDiffHunksAtCommit(commitID, diffFiles);
       this.diffFiles = diffFiles;
     }
     return diffFiles;

--- a/diff/src/main/java/edu/pku/code2graph/diff/cochange/ChangesCollector.java
+++ b/diff/src/main/java/edu/pku/code2graph/diff/cochange/ChangesCollector.java
@@ -5,6 +5,8 @@ import com.google.gson.GsonBuilder;
 import edu.pku.code2graph.diff.RepoAnalyzer;
 import edu.pku.code2graph.diff.model.DiffFile;
 import edu.pku.code2graph.diff.model.FileType;
+import edu.pku.code2graph.exception.InvalidRepoException;
+import edu.pku.code2graph.exception.NonexistPathException;
 import edu.pku.code2graph.util.FileUtil;
 import org.apache.log4j.PropertyConfigurator;
 import org.json.simple.JSONArray;
@@ -20,9 +22,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.*;
 
-/**
- * Collect xml and java changes/diffs in each commit as the Ground Truth
- */
+/** Collect xml and java changes/diffs in each commit as the Ground Truth */
 public class ChangesCollector {
 
   static Logger logger = LoggerFactory.getLogger(ChangesCollector.class);
@@ -39,12 +39,13 @@ public class ChangesCollector {
     repoPath = Config.repoPath;
     try {
       collectChangesForRepo();
-    } catch (IOException e) {
+    } catch (IOException | NonexistPathException | InvalidRepoException e) {
       e.printStackTrace();
     }
   }
 
-  private static void collectChangesForRepo() throws IOException {
+  private static void collectChangesForRepo()
+      throws IOException, NonexistPathException, InvalidRepoException {
 
     List<String> focusList = new ArrayList<>();
     //    focusList.add("111a0f9f171341f2c35f1c10cdddcb9dcf53f405");

--- a/diff/src/main/java/edu/pku/code2graph/diff/cochange/CoChangeHint.java
+++ b/diff/src/main/java/edu/pku/code2graph/diff/cochange/CoChangeHint.java
@@ -9,6 +9,8 @@ import edu.pku.code2graph.diff.util.Counter;
 import edu.pku.code2graph.diff.util.GitService;
 import edu.pku.code2graph.diff.util.GitServiceCGit;
 import edu.pku.code2graph.diff.util.MetricUtil;
+import edu.pku.code2graph.exception.InvalidRepoException;
+import edu.pku.code2graph.exception.NonexistPathException;
 import edu.pku.code2graph.gen.Generator;
 import edu.pku.code2graph.gen.Generators;
 import edu.pku.code2graph.gen.Register;
@@ -70,7 +72,8 @@ public class CoChangeHint {
             });
   }
 
-  public static void main(String[] args) throws IOException {
+  public static void main(String[] args)
+      throws IOException, NonexistPathException, InvalidRepoException {
 
     List<String> focusList = new ArrayList<>();
     //    focusList.add("111a0f9f171341f2c35f1c10cdddcb9dcf53f405");

--- a/diff/src/main/java/edu/pku/code2graph/diff/cochange/CoChangeHint.java
+++ b/diff/src/main/java/edu/pku/code2graph/diff/cochange/CoChangeHint.java
@@ -81,7 +81,7 @@ public class CoChangeHint {
     repoName = Config.repoName;
     repoPath = Config.repoPath;
     RepoAnalyzer repoAnalyzer = new RepoAnalyzer(repoName, repoPath);
-    GitService gitService = new GitServiceCGit();
+    GitService gitService = new GitServiceCGit(repoPath);
 
     System.out.printf("Processing repo: %s at %s %n", repoName, repoPath);
     List<String> dataFilePaths =
@@ -777,7 +777,7 @@ public class CoChangeHint {
     Counter<Triple<String, String, String>> membersCounter = new Counter<>();
 
     // note that here "HEAD" is the tested commit, since we have checkout to it before
-    List<String> commitIDs = gitService.getCommitsChangedFile(repoPath, path, "HEAD", 10);
+    List<String> commitIDs = gitService.getCommitsChangedFile(path, "HEAD", 10);
     int numAllCommits = commitIDs.size();
     // count the number of co-change commits
 
@@ -868,7 +868,7 @@ public class CoChangeHint {
     Map<String, Integer> commitCounter = new HashMap<>();
     for (String xmlFilePath : xmlDiffs.keySet()) {
       // note that here "HEAD" is the tested commit, since we have checkout to it before
-      List<String> commitIDs = gitService.getCommitsChangedFile(repoPath, xmlFilePath, "HEAD", 10);
+      List<String> commitIDs = gitService.getCommitsChangedFile(xmlFilePath, "HEAD", 10);
       for (String commitID : commitIDs) {
         commitCounter.merge(commitID, 1, Integer::sum);
       }

--- a/diff/src/main/java/edu/pku/code2graph/diff/util/GitService.java
+++ b/diff/src/main/java/edu/pku/code2graph/diff/util/GitService.java
@@ -12,38 +12,37 @@ import java.util.List;
 /** A list of helper functions related with Git */
 public interface GitService {
   Logger logger = LoggerFactory.getLogger(GitService.class);
-  boolean ignoreWhiteChanges = false;
 
   /**
    * Get the diff files in the current working tree
    *
    * @return
    */
-  ArrayList<DiffFile> getChangedFilesInWorkingTree(String repoPath);
+  ArrayList<DiffFile> getChangedFilesInWorkingTree();
 
   /**
    * Get the diff files between one commit and its previous commit
    *
    * @return
    */
-  ArrayList<DiffFile> getChangedFilesAtCommit(String repoPath, String commitID);
+  ArrayList<DiffFile> getChangedFilesAtCommit( String commitID);
 
   /**
    * Get the diff hunks in the current working tree
    *
-   * @param repoPath
+   * 
    * @return
    */
-  List<DiffHunk> getDiffHunksInWorkingTree(String repoPath, List<DiffFile> diffFiles);
+  List<DiffHunk> getDiffHunksInWorkingTree( List<DiffFile> diffFiles);
 
   /**
    * Get the diff hunks between one commit and its previous commit
    *
-   * @param repoPath
+   * 
    * @param commitID
    * @return
    */
-  List<DiffHunk> getDiffHunksAtCommit(String repoPath, String commitID, List<DiffFile> diffFiles);
+  List<DiffHunk> getDiffHunksAtCommit( String commitID, List<DiffFile> diffFiles);
 
   /**
    * Get the file content at HEAD
@@ -51,7 +50,7 @@ public interface GitService {
    * @param relativePath
    * @return
    */
-  String getContentAtHEAD(Charset charset, String repoDir, String relativePath);
+  String getContentAtHEAD(Charset charset, String relativePath);
 
   /**
    * Get the file content at one specific commit
@@ -59,62 +58,61 @@ public interface GitService {
    * @param relativePath
    * @returnØØ
    */
-  String getContentAtCommit(Charset charset, String repoDir, String relativePath, String commitID);
+  String getContentAtCommit(Charset charset, String relativePath, String commitID);
 
   /**
    * Get the name of the author of a commit
    *
-   * @param repoDir
+
    * @param commitID
    * @return
    */
-  String getCommitterName(String repoDir, String commitID);
+  String getCommitterName(String commitID);
 
   /**
    * Get the email of the author of a commit
    *
-   * @param repoDir
+
    * @param commitID
    * @return
    */
-  String getCommitterEmail(String repoDir, String commitID);
+  String getCommitterEmail(String commitID);
 
   /**
    * Get commits that ever changed a specific file before a commit
    *
-   * @param repoDir
    * @param filePath
    * @param beforeCommit
    * @param maxNumber
    * @return
    */
   List<String> getCommitsChangedFile(
-      String repoDir, String filePath, String beforeCommit, int... maxNumber);
+      String filePath, String beforeCommit, int... maxNumber);
 
   /**
    * Get commits that ever changed a specific line range before HEAD
    *
-   * @param repoDir
+
    * @param filePath
    * @return
    */
   List<String> getCommitsChangedLineRange(
-      String repoDir, String filePath, int startLine, int endLine);
+   String filePath, int startLine, int endLine);
 
   /**
    * Get current commit id of repo
    *
-   * @param repoDir
+
    * @return
    */
-  String getHEADCommitId(String repoDir);
+  String getHEADCommitId();
 
   /**
    * Checkout the repo to specific commitID
    *
-   * @param repoDir
+
    * @param commitID
    * @return success or not
    */
-  boolean checkoutByCommitID(String repoDir, String commitID);
+  boolean checkoutByCommitID(String commitID);
 }

--- a/diff/src/main/java/edu/pku/code2graph/diff/util/GitServiceCGit.java
+++ b/diff/src/main/java/edu/pku/code2graph/diff/util/GitServiceCGit.java
@@ -5,11 +5,14 @@ import edu.pku.code2graph.diff.textualdiffparser.api.DiffParser;
 import edu.pku.code2graph.diff.textualdiffparser.api.UnifiedDiffParser;
 import edu.pku.code2graph.diff.textualdiffparser.api.model.Diff;
 import edu.pku.code2graph.diff.textualdiffparser.api.model.Line;
+import edu.pku.code2graph.exception.InvalidRepoException;
+import edu.pku.code2graph.exception.NonexistPathException;
 import edu.pku.code2graph.util.FileUtil;
 import edu.pku.code2graph.util.SysUtil;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -20,7 +23,15 @@ public class GitServiceCGit implements GitService {
   private boolean ignoreWhiteChanges = false;
   private final String repoPath;
 
-  public GitServiceCGit(String repoPath) {
+  public GitServiceCGit(String repoPath)
+      throws NonexistPathException, IOException, InvalidRepoException {
+    if (!FileUtil.checkExists(repoPath)) {
+      throw new NonexistPathException("Repo", repoPath);
+    }
+    // check if the given path is the root of a git repo
+    if (!FileUtil.isSubDirectory(".git", repoPath)) {
+      throw new InvalidRepoException(repoPath);
+    }
     this.repoPath = repoPath;
   }
 

--- a/diff/src/main/java/edu/pku/code2graph/diff/util/GitServiceCGit.java
+++ b/diff/src/main/java/edu/pku/code2graph/diff/util/GitServiceCGit.java
@@ -18,6 +18,11 @@ import java.util.List;
 /** Implementation of helper functions based on the output of git commands. */
 public class GitServiceCGit implements GitService {
   private boolean ignoreWhiteChanges = false;
+  private final String repoPath;
+
+  public GitServiceCGit(String repoPath) {
+    this.repoPath = repoPath;
+  }
 
   public void setIgnoreWhiteChanges(boolean ignoreWhiteChanges) {
     this.ignoreWhiteChanges = ignoreWhiteChanges;
@@ -29,7 +34,7 @@ public class GitServiceCGit implements GitService {
    * @return
    */
   @Override
-  public ArrayList<DiffFile> getChangedFilesInWorkingTree(String repoPath) {
+  public ArrayList<DiffFile> getChangedFilesInWorkingTree() {
     // unstage the staged files first
     //    SysUtil.runSystemCommand(repoPath, "git", "restore", "--staged", ".");
     SysUtil.runSystemCommand(repoPath, StandardCharsets.UTF_8, "git", "reset", "HEAD", ".");
@@ -69,9 +74,7 @@ public class GitServiceCGit implements GitService {
                   charset,
                   relativePath,
                   relativePath,
-                  (fileType == FileType.BIN
-                      ? ""
-                      : getContentAtHEAD(charset, repoPath, relativePath)),
+                  (fileType == FileType.BIN ? "" : getContentAtHEAD(charset, relativePath)),
                   (fileType == FileType.BIN ? "" : FileUtil.readFileToString(absolutePath)));
           break;
         case ADDED:
@@ -90,7 +93,7 @@ public class GitServiceCGit implements GitService {
           break;
         case DELETED:
           // charset and filetype of the deleted is hard to detect
-          if (checkBinaryFileByDiff(repoPath, relativePath, charset)) {
+          if (checkBinaryFileByDiff(relativePath, charset)) {
             fileType = FileType.BIN;
           }
           DiffFile =
@@ -101,9 +104,7 @@ public class GitServiceCGit implements GitService {
                   StandardCharsets.UTF_8,
                   relativePath,
                   "",
-                  (fileType == FileType.BIN
-                      ? ""
-                      : getContentAtHEAD(charset, repoPath, relativePath)),
+                  (fileType == FileType.BIN ? "" : getContentAtHEAD(charset, relativePath)),
                   "");
           break;
         case RENAMED:
@@ -123,7 +124,7 @@ public class GitServiceCGit implements GitService {
                     charset,
                     oldPath,
                     newPath,
-                    (fileType == FileType.BIN ? "" : getContentAtHEAD(charset, repoPath, oldPath)),
+                    (fileType == FileType.BIN ? "" : getContentAtHEAD(charset, oldPath)),
                     (fileType == FileType.BIN ? "" : FileUtil.readFileToString(newAbsPath)));
           } else if (temp.length == 3) {
             // CXX/RXX aaa bbb
@@ -140,7 +141,7 @@ public class GitServiceCGit implements GitService {
                     charset,
                     oldPath,
                     newPath,
-                    (fileType == FileType.BIN ? "" : getContentAtHEAD(charset, repoPath, oldPath)),
+                    (fileType == FileType.BIN ? "" : getContentAtHEAD(charset, oldPath)),
                     (fileType == FileType.BIN ? "" : FileUtil.readFileToString(newAbsPath)));
           }
           break;
@@ -161,7 +162,7 @@ public class GitServiceCGit implements GitService {
    * @return
    */
   @Override
-  public ArrayList<DiffFile> getChangedFilesAtCommit(String repoPath, String commitID) {
+  public ArrayList<DiffFile> getChangedFilesAtCommit(String commitID) {
     // git diff <start_commit> <end_commit>
     // on Windows the ~ character must be used instead of ^
     String output =
@@ -171,7 +172,7 @@ public class GitServiceCGit implements GitService {
             "git",
             "diff",
             "--name-status",
-            getParentCommitID(repoPath, commitID),
+            getParentCommitID(commitID),
             commitID);
     // early return
     if (output.trim().isEmpty()) {
@@ -203,10 +204,10 @@ public class GitServiceCGit implements GitService {
                   relativePath,
                   (fileType == FileType.BIN
                       ? ""
-                      : getContentAtCommit(charset, repoPath, relativePath, commitID + "~")),
+                      : getContentAtCommit(charset, relativePath, commitID + "~")),
                   (fileType == FileType.BIN
                       ? ""
-                      : getContentAtCommit(charset, repoPath, relativePath, commitID)));
+                      : getContentAtCommit(charset, relativePath, commitID)));
           break;
         case ADDED:
         case UNTRACKED:
@@ -221,7 +222,7 @@ public class GitServiceCGit implements GitService {
                   "",
                   (fileType == FileType.BIN
                       ? ""
-                      : getContentAtCommit(charset, repoPath, relativePath, commitID)));
+                      : getContentAtCommit(charset, relativePath, commitID)));
           break;
         case DELETED:
           diffFile =
@@ -234,7 +235,7 @@ public class GitServiceCGit implements GitService {
                   "",
                   (fileType == FileType.BIN
                       ? ""
-                      : getContentAtCommit(charset, repoPath, relativePath, commitID + "~")),
+                      : getContentAtCommit(charset, relativePath, commitID + "~")),
                   "");
           break;
         case RENAMED:
@@ -254,10 +255,10 @@ public class GitServiceCGit implements GitService {
                     newPath,
                     (fileType == FileType.BIN
                         ? ""
-                        : getContentAtCommit(charset, repoPath, oldPath, commitID + "~")),
+                        : getContentAtCommit(charset, oldPath, commitID + "~")),
                     (fileType == FileType.BIN
                         ? ""
-                        : getContentAtCommit(charset, repoPath, newPath, commitID)));
+                        : getContentAtCommit(charset, newPath, commitID)));
           } else if (temp.length == 3) {
             // CXX/RXX aaa bbb
             String oldPath = temp[1];
@@ -273,10 +274,10 @@ public class GitServiceCGit implements GitService {
                     newPath,
                     (fileType == FileType.BIN
                         ? ""
-                        : getContentAtCommit(charset, repoPath, oldPath, commitID + "~")),
+                        : getContentAtCommit(charset, oldPath, commitID + "~")),
                     (fileType == FileType.BIN
                         ? ""
-                        : getContentAtCommit(charset, repoPath, newPath, commitID)));
+                        : getContentAtCommit(charset, newPath, commitID)));
           }
           break;
         default:
@@ -291,7 +292,7 @@ public class GitServiceCGit implements GitService {
   }
 
   @Override
-  public List<DiffHunk> getDiffHunksInWorkingTree(String repoPath, List<DiffFile> diffFiles) {
+  public List<DiffHunk> getDiffHunksInWorkingTree(List<DiffFile> diffFiles) {
     // unstage the staged files first
     //    SysUtil.runSystemCommand(repoPath, "git", "reset", "--mixed");
     SysUtil.runSystemCommand(repoPath, StandardCharsets.UTF_8, "git", "reset", "HEAD", ".");
@@ -346,7 +347,7 @@ public class GitServiceCGit implements GitService {
       diffs = parser.parse(new ByteArrayInputStream(diffOutput.toString().getBytes()));
     }
 
-    return generateDiffHunks(repoPath, diffs, diffFiles);
+    return generateDiffHunks(diffs, diffFiles);
   }
 
   private DiffHunk createDiffHunkForBinaryFile(DiffFile diffFile) {
@@ -392,8 +393,7 @@ public class GitServiceCGit implements GitService {
    * @param diffs
    * @return
    */
-  private List<DiffHunk> generateDiffHunks(
-      String repoPath, List<Diff> diffs, List<DiffFile> diffFiles) {
+  private List<DiffHunk> generateDiffHunks(List<Diff> diffs, List<DiffFile> diffFiles) {
     List<DiffHunk> allDiffHunks = new ArrayList<>();
     // one file, one diff
     // UNTRACKED/ADDED files won't be shown in the diff
@@ -566,13 +566,11 @@ public class GitServiceCGit implements GitService {
   /**
    * Get the diff hunks between one commit and its previous commit
    *
-   * @param repoPath
    * @param commitID
    * @return
    */
   @Override
-  public List<DiffHunk> getDiffHunksAtCommit(
-      String repoPath, String commitID, List<DiffFile> diffFiles) {
+  public List<DiffHunk> getDiffHunksAtCommit(String commitID, List<DiffFile> diffFiles) {
     // git diff <start_commit> <end_commit>
     // on Windows the ~ character must be used instead of ^
     String diffOutput =
@@ -587,7 +585,7 @@ public class GitServiceCGit implements GitService {
                 "--ignore-blank-lines",
                 "--ignore-space-change",
                 "-U0",
-                getParentCommitID(repoPath, commitID),
+                getParentCommitID(commitID),
                 commitID)
             : SysUtil.runSystemCommand(
                 repoPath, StandardCharsets.UTF_8, "git", "diff", "-U0", commitID + "~", commitID);
@@ -598,7 +596,7 @@ public class GitServiceCGit implements GitService {
       diffs = parser.parse(new ByteArrayInputStream(diffOutput.getBytes()));
     }
 
-    return generateDiffHunks(repoPath, diffs, diffFiles);
+    return generateDiffHunks(diffs, diffFiles);
   }
 
   /**
@@ -608,8 +606,8 @@ public class GitServiceCGit implements GitService {
    * @return
    */
   @Override
-  public String getContentAtHEAD(Charset charset, String repoDir, String relativePath) {
-    return SysUtil.runSystemCommand(repoDir, charset, "git", "show", "HEAD:" + relativePath);
+  public String getContentAtHEAD(Charset charset, String relativePath) {
+    return SysUtil.runSystemCommand(repoPath, charset, "git", "show", "HEAD:" + relativePath);
   }
 
   /**
@@ -619,10 +617,10 @@ public class GitServiceCGit implements GitService {
    * @return
    */
   @Override
-  public String getContentAtCommit(
-      Charset charset, String repoDir, String relativePath, String commitID) {
+  public String getContentAtCommit(Charset charset, String relativePath, String commitID) {
     // TOFIX: if there is any error, like not exist in this commit, error message will be content
-    return SysUtil.runSystemCommand(repoDir, charset, "git", "show", commitID + ":" + relativePath);
+    return SysUtil.runSystemCommand(
+        repoPath, charset, "git", "show", commitID + ":" + relativePath);
   }
 
   /**
@@ -646,10 +644,8 @@ public class GitServiceCGit implements GitService {
 
   /**
    * Make the working dir clean by dropping all the changes (which are backed up in tempDir/current)
-   *
-   * @param repoPath
    */
-  public boolean clearWorkingTree(String repoPath) {
+  public boolean clearWorkingTree() {
     SysUtil.runSystemCommand(repoPath, StandardCharsets.UTF_8, "git", "reset", "--hard");
     String status =
         SysUtil.runSystemCommand(
@@ -659,27 +655,27 @@ public class GitServiceCGit implements GitService {
   }
 
   @Override
-  public String getCommitterName(String repoDir, String commitID) {
+  public String getCommitterName(String commitID) {
     // git show HEAD | grep Author
     // git log -1 --format='%an' HASH
     // git show -s --format='%an' HASH
     return SysUtil.runSystemCommand(
-            repoDir, StandardCharsets.UTF_8, "git", "show", "-s", "--format='%an'", commitID)
+            repoPath, StandardCharsets.UTF_8, "git", "show", "-s", "--format='%an'", commitID)
         .trim()
         .replaceAll("'", "");
   }
 
   @Override
-  public String getCommitterEmail(String repoDir, String commitID) {
+  public String getCommitterEmail(String commitID) {
     // git log -1 --format='%ae' HASH
     // git show -s --format='%ae' HASH
     return SysUtil.runSystemCommand(
-            repoDir, StandardCharsets.UTF_8, "git", "show", "-s", "--format='%ae'", commitID)
+            repoPath, StandardCharsets.UTF_8, "git", "show", "-s", "--format='%ae'", commitID)
         .trim()
         .replaceAll("'", "");
   }
 
-  private boolean checkBinaryFileByDiff(String repoPath, String filePath, Charset charset) {
+  private boolean checkBinaryFileByDiff(String filePath, Charset charset) {
     String output =
         SysUtil.runSystemCommand(repoPath, charset, "git", "diff", "-U0", "--", filePath);
     // e.g. Binary files a/11.png and /dev/null differ
@@ -692,16 +688,16 @@ public class GitServiceCGit implements GitService {
 
   @Override
   public List<String> getCommitsChangedFile(
-      String repoDir, String filePath, String beforeCommit, int... maxNumber) {
+      String filePath, String beforeCommit, int... maxNumber) {
     String output = "";
     if (maxNumber.length == 0) {
       output =
           SysUtil.runSystemCommand(
-              repoDir, StandardCharsets.UTF_8, "git", "rev-list", beforeCommit, filePath);
+              repoPath, StandardCharsets.UTF_8, "git", "rev-list", beforeCommit, filePath);
     } else if (maxNumber.length == 1) {
       output =
           SysUtil.runSystemCommand(
-              repoDir,
+              repoPath,
               StandardCharsets.UTF_8,
               "git",
               "rev-list",
@@ -718,15 +714,14 @@ public class GitServiceCGit implements GitService {
   }
 
   @Override
-  public List<String> getCommitsChangedLineRange(
-      String repoDir, String filePath, int startLine, int endLine) {
+  public List<String> getCommitsChangedLineRange(String filePath, int startLine, int endLine) {
     // git log --pretty=format:"%H" -u -L <start_line_number>,<ending_line_number>:<filename>
     // --no-patch
     // git log--format=format:%H -u -L <start_line_number>,<ending_line_number>:<filename>
     // --no-patch
     String output =
         SysUtil.runSystemCommand(
-            repoDir,
+            repoPath,
             StandardCharsets.UTF_8,
             "git",
             "log",
@@ -748,11 +743,11 @@ public class GitServiceCGit implements GitService {
    * @param commitID
    * @return
    */
-  private String getParentCommitID(String repoDir, String commitID) {
+  private String getParentCommitID(String commitID) {
     // TODO: refactor GitService to save repoDir and fixed data
     String firstCommitID =
         SysUtil.runSystemCommand(
-                repoDir, StandardCharsets.UTF_8, "git", "rev-list", "--max-parents=0", "HEAD")
+                repoPath, StandardCharsets.UTF_8, "git", "rev-list", "--max-parents=0", "HEAD")
             .trim();
     if (commitID.equals(firstCommitID)) {
       return "4b825dc642cb6eb9a060e54bf8d69288fbee4904"; // what the fck?
@@ -762,17 +757,17 @@ public class GitServiceCGit implements GitService {
   }
 
   @Override
-  public String getHEADCommitId(String repoDir) {
+  public String getHEADCommitId() {
     String output =
         SysUtil.runSystemCommand(
-            repoDir, StandardCharsets.UTF_8, "git", "rev-parse", "--short", "HEAD");
+            repoPath, StandardCharsets.UTF_8, "git", "rev-parse", "--short", "HEAD");
     return output.trim();
   }
 
   @Override
-  public boolean checkoutByCommitID(String repoDir, String commitID) {
-    SysUtil.runSystemCommand(repoDir, StandardCharsets.UTF_8, "git", "checkout", "-f", commitID);
-    String curId = getHEADCommitId(repoDir);
+  public boolean checkoutByCommitID(String commitID) {
+    SysUtil.runSystemCommand(repoPath, StandardCharsets.UTF_8, "git", "checkout", "-f", commitID);
+    String curId = getHEADCommitId();
     return curId.equals(commitID);
   }
 }

--- a/diff/src/main/java/edu/pku/code2graph/diff/util/GitServiceCGit.java
+++ b/diff/src/main/java/edu/pku/code2graph/diff/util/GitServiceCGit.java
@@ -29,9 +29,11 @@ public class GitServiceCGit implements GitService {
       throw new NonexistPathException("Repo", repoPath);
     }
     // check if the given path is the root of a git repo
-    if (!FileUtil.isSubDirectory(".git", repoPath)) {
+    File file = new File(repoPath + File.separator + ".git");
+    if (!file.exists() || !file.isDirectory()) {
       throw new InvalidRepoException(repoPath);
     }
+
     this.repoPath = repoPath;
   }
 

--- a/diff/src/main/java/edu/pku/code2graph/diff/util/GitServiceJGit.java
+++ b/diff/src/main/java/edu/pku/code2graph/diff/util/GitServiceJGit.java
@@ -2,7 +2,6 @@ package edu.pku.code2graph.diff.util;
 
 import edu.pku.code2graph.diff.model.DiffFile;
 import edu.pku.code2graph.diff.model.DiffHunk;
-import edu.pku.code2graph.util.SysUtil;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.lib.RepositoryBuilder;
@@ -12,7 +11,6 @@ import org.eclipse.jgit.revwalk.RevWalk;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -23,41 +21,45 @@ import java.util.List;
  * faster due to the saving for spawning OS process in shell script.
  */
 public class GitServiceJGit implements GitService {
+  private final String repoPath;
+
+  public GitServiceJGit(String repoPath) {
+    this.repoPath = repoPath;
+  }
+
   @Override
-  public ArrayList<DiffFile> getChangedFilesInWorkingTree(String repoPath) {
+  public ArrayList<DiffFile> getChangedFilesInWorkingTree() {
     return null;
   }
 
   @Override
-  public ArrayList<DiffFile> getChangedFilesAtCommit(String repoPath, String commitID) {
+  public ArrayList<DiffFile> getChangedFilesAtCommit(String commitID) {
     return null;
   }
 
   @Override
-  public List<DiffHunk> getDiffHunksInWorkingTree(String repoPath, List<DiffFile> diffFiles) {
+  public List<DiffHunk> getDiffHunksInWorkingTree(List<DiffFile> diffFiles) {
     return null;
   }
 
   @Override
-  public List<DiffHunk> getDiffHunksAtCommit(
-      String repoPath, String commitID, List<DiffFile> diffFiles) {
+  public List<DiffHunk> getDiffHunksAtCommit(String commitID, List<DiffFile> diffFiles) {
     return null;
   }
 
   @Override
-  public String getContentAtHEAD(Charset charset, String repoDir, String relativePath) {
+  public String getContentAtHEAD(Charset charset, String relativePath) {
     return null;
   }
 
   @Override
-  public String getContentAtCommit(
-      Charset charset, String repoDir, String relativePath, String commitID) {
+  public String getContentAtCommit(Charset charset, String relativePath, String commitID) {
     return null;
   }
 
   @Override
-  public String getCommitterName(String repoDir, String commitID) {
-    RevCommit commit = getCommitFromID(repoDir, commitID);
+  public String getCommitterName(String commitID) {
+    RevCommit commit = getCommitFromID(commitID);
     if (null != commit) {
       return commit.getAuthorIdent().getName();
     }
@@ -65,16 +67,16 @@ public class GitServiceJGit implements GitService {
   }
 
   @Override
-  public String getCommitterEmail(String repoDir, String commitID) {
-    RevCommit commit = getCommitFromID(repoDir, commitID);
+  public String getCommitterEmail(String commitID) {
+    RevCommit commit = getCommitFromID(commitID);
     if (null != commit) {
       return commit.getAuthorIdent().getEmailAddress();
     }
     return "";
   }
 
-  private RevCommit getCommitFromID(String repoDir, String commitID) {
-    Path path = Paths.get(repoDir);
+  private RevCommit getCommitFromID(String commitID) {
+    Path path = Paths.get(repoPath);
     try (Git git = Git.open(path.toFile())) {
       Repository repository = git.getRepository();
       RevWalk walk = new RevWalk(repository);
@@ -141,23 +143,22 @@ public class GitServiceJGit implements GitService {
 
   @Override
   public List<String> getCommitsChangedFile(
-      String repoDir, String filePath, String beforeCommit, int... maxNumber) {
+      String filePath, String beforeCommit, int... maxNumber) {
     return new ArrayList<>();
   }
 
   @Override
-  public List<String> getCommitsChangedLineRange(
-      String repoDir, String filePath, int startLine, int endLine) {
+  public List<String> getCommitsChangedLineRange(String filePath, int startLine, int endLine) {
     return new ArrayList<>();
   }
 
   @Override
-  public String getHEADCommitId(String repoDir) {
+  public String getHEADCommitId() {
     return "HEAD";
   }
 
   @Override
-  public boolean checkoutByCommitID(String repoDir, String commitID) {
+  public boolean checkoutByCommitID(String commitID) {
     return false;
   }
 }

--- a/xll/src/main/java/edu/pku/code2graph/xll/Config.java
+++ b/xll/src/main/java/edu/pku/code2graph/xll/Config.java
@@ -3,6 +3,7 @@ package edu.pku.code2graph.xll;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class Config {
   private List<String> presets;
@@ -14,7 +15,7 @@ public class Config {
 
   public Config(Map<String, Object> config) {
     Object rules_raw = config.getOrDefault("rules", new ArrayList<>());
-    rules = ((List<Map<String, Object>>) rules_raw).stream().map(Rule::new).toList();
+    rules = ((List<Map<String, Object>>) rules_raw).stream().map(Rule::new).collect(Collectors.toList());;
     presets = (List<String>) config.getOrDefault("presets", new ArrayList<>());
     word_sep = (String) config.getOrDefault("word_sep", "");
     plugins = (List<String>) config.getOrDefault("plugins", new ArrayList<>());


### PR DESCRIPTION
重构了GitService的使用方式，将所有方法都需要的repoPath参数提取为field

改动较大，需要review一下

与#47 #49 等相关