### PR TITLE
feat: add varType for field decl

### DIFF
--- a/core/src/main/java/edu/pku/code2graph/model/Layer.java
+++ b/core/src/main/java/edu/pku/code2graph/model/Layer.java
@@ -40,7 +40,16 @@ public class Layer implements Serializable {
     }
 
     public String toString() {
-        return language.toString() + "://" + identifier;
+        StringBuilder builder = new StringBuilder(identifier);
+        builder.append("[");
+        boolean flag = false;
+        for (String key : attributes.keySet()) {
+            if (flag) builder.append(",");
+            builder.append(key).append("=").append(getAttribute(key));
+            flag = true;
+        }
+        builder.append("]");
+        return builder.toString();
     }
 
     public int hashCode() {

--- a/core/src/main/java/edu/pku/code2graph/model/URILike.java
+++ b/core/src/main/java/edu/pku/code2graph/model/URILike.java
@@ -28,7 +28,7 @@ public abstract class URILike<T extends Layer> {
         output.append(isRef ? "use" : "def");
         output.append(":");
         for (Layer layer : layers) {
-            output.append("//").append(layer.getIdentifier());
+            output.append("//").append(layer.toString());
         }
         return output.append(">").toString();
     }

--- a/gen.java/src/main/java/edu/pku/code2graph/gen/jdt/ExpressionVisitor.java
+++ b/gen.java/src/main/java/edu/pku/code2graph/gen/jdt/ExpressionVisitor.java
@@ -291,6 +291,7 @@ public class ExpressionVisitor extends AbstractJdtVisitor {
               JdtService.getIdentifier(fragment));
 
       node.setRange(computeRange(fragment));
+      node.getUri().getLayer(1).addAttribute("varType", fd.getType().toString());
 
       // annotations
       parseAnnotations(fd.modifiers(), node);


### PR DESCRIPTION
同时改了 uri 的输出形式，将 attr 添加到每个 layer 的尾部。例如：

```
foo[]//bar[varType=baz]
```

这主要是因为 layer 需要在 uri 匹配中承担与 identifier 类似的作用。

如果这个改动无法接受，我会撤回这个提交: 164a8061818e7b0738c805ffa49cb6848ae2689b
