### PR TITLE
feat: support attribute pattern matching

### DIFF
--- a/core/src/main/java/edu/pku/code2graph/model/Layer.java
+++ b/core/src/main/java/edu/pku/code2graph/model/Layer.java
@@ -1,51 +1,46 @@
 package edu.pku.code2graph.model;
 
-import java.io.Serializable;
 import java.util.HashMap;
-import java.util.Map;
 
-public class Layer implements Serializable {
-    protected Language language;
-    protected String identifier;
-    protected Map<String, String> attributes;
-
+public class Layer extends HashMap<String, String> {
     public Layer(String identifier, Language language) {
-        this.language = language;
-        this.identifier = identifier;
-        this.attributes = new HashMap<>();
+        super();
+        put("identifier", identifier);
+        put("language", language.toString());
     }
 
     public Language getLanguage() {
-        return language;
+        return Language.valueOf(get("language"));
     }
 
     public String getIdentifier() {
-        return identifier;
+        return get("identifier");
     }
 
     public void setLanguage(Language language) {
-        this.language = language;
+        put("language", language.toString());
     }
 
     public void setIdentifier(String identifier) {
-        this.identifier = identifier;
+        put("identifier", identifier);
     }
 
     public void addAttribute(String key, String value) {
-        attributes.put(key, value);
+        put(key, value);
     }
 
     public String getAttribute(String key) {
-        return attributes.get(key);
+        return get(key);
     }
 
     public String toString() {
-        StringBuilder builder = new StringBuilder(identifier);
+        StringBuilder builder = new StringBuilder(get("identifier"));
         builder.append("[");
         boolean flag = false;
-        for (String key : attributes.keySet()) {
+        for (String key : keySet()) {
+            if (key.equals("identifier")) continue;
             if (flag) builder.append(",");
-            builder.append(key).append("=").append(getAttribute(key));
+            builder.append(key).append("=").append(get(key));
             flag = true;
         }
         builder.append("]");

--- a/gen.html/src/main/java/edu/pku/code2graph/gen/html/SpringHandler.java
+++ b/gen.html/src/main/java/edu/pku/code2graph/gen/html/SpringHandler.java
@@ -76,11 +76,11 @@ public class SpringHandler extends AbstractHandler {
         parentIdtf + ((parentIdtf.isEmpty()) ? "" : "/") + URI.checkInvalidCh(current.getName());
     URI uri = new URI(true, uriFilePath);
     uri.addLayer(getIdentifier(attrName), Language.HTML);
-    uri.addLayer(curIdtf, Language.OTHER);
+    uri.addLayer(curIdtf, Language.ANY);
     ElementNode en =
         new ElementNode(
             GraphUtil.nid(),
-            Language.OTHER,
+            Language.ANY,
             NodeType.INLINE_VAR,
             current.getSnippet(),
             current.getName(),

--- a/xll/src/main/java/edu/pku/code2graph/xll/Capture.java
+++ b/xll/src/main/java/edu/pku/code2graph/xll/Capture.java
@@ -46,6 +46,7 @@ public final class Capture extends TreeMap<String, String> {
         greedy.addAll(capture.greedy);
     }
 
+    @Override
     public String toString() {
         String result = super.toString();
         result += greedy.toString();
@@ -54,8 +55,7 @@ public final class Capture extends TreeMap<String, String> {
 
     public Capture clone() {
         Capture result = (Capture) super.clone();
-        result.putAll(this);
-        result.greedy.addAll(greedy);
+        result.merge(this);
         return result;
     }
 }

--- a/xll/src/main/java/edu/pku/code2graph/xll/IdentifierPattern.java
+++ b/xll/src/main/java/edu/pku/code2graph/xll/IdentifierPattern.java
@@ -68,7 +68,11 @@ public class IdentifierPattern {
       source = String.join("([\\w-.]+)", segments);
     }
 
-    target = target.replace("\\/", "__slash__");
+    target = target
+        .replace("-", "")
+        .replace("_", "")
+        .replace("\\/", "__slash__")
+        .toLowerCase();
 
     Pattern regexp = Pattern.compile(source, Pattern.CASE_INSENSITIVE);
     Matcher matcher = regexp.matcher(target);
@@ -78,10 +82,7 @@ public class IdentifierPattern {
     int count = matcher.groupCount();
     for (int i = 1; i <= count; ++i) {
       String value = matcher.group(i)
-          .replace("__slash__", "/")
-          .replace("-", "")
-          .replace("_", "")
-          .toLowerCase();
+          .replace("__slash__", "/");
       Token token = symbols.get(i - 1);
       if (token.modifier.equals("dot")) {
         value = value.replace(".", "/");

--- a/xll/src/main/java/edu/pku/code2graph/xll/IdentifierPattern.java
+++ b/xll/src/main/java/edu/pku/code2graph/xll/IdentifierPattern.java
@@ -1,0 +1,94 @@
+package edu.pku.code2graph.xll;
+
+import edu.pku.code2graph.model.Language;
+import edu.pku.code2graph.model.Layer;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class IdentifierPattern {
+  public static final Pattern VARIABLE = Pattern.compile("\\(&?(\\w+)(?::(\\w+))?((\\\\\\.){3})?\\)");
+
+  private final boolean pass;
+  private int offset = 0;
+  private String source;
+  private String leading;
+  private final List<Token> tokens = new ArrayList<>();
+  public final List<String> anchors = new ArrayList<>();
+  public final List<Token> symbols = new ArrayList<>();
+
+  public IdentifierPattern(String identifier) {
+    pass = identifier.equals("**");
+    if (pass) return;
+
+    source =
+        ("**/" + identifier)
+            .replaceAll("\\\\/", "__slash__")
+            .replaceAll("\\\\", "\\\\\\\\")
+            .replaceAll("\\.", "\\\\.")
+            .replaceAll("\\^", "\\\\^")
+            .replaceAll("\\$", "\\\\\\$")
+            .replaceAll("\\+", "\\\\+")
+            .replaceAll("\\*\\*/", "(?:.+/)?")
+            .replaceAll("\\*", "\\\\w+")
+            .replaceAll("\\{", "\\\\{");
+
+    Matcher matcher = VARIABLE.matcher(source);
+    while (matcher.find()) {
+      Token token = new Token(matcher);
+      if (token.isGreedy) {
+        leading = token.name;
+        source = source.substring(8);
+        offset = 8;
+      }
+      if (token.isAnchor) {
+        anchors.add(token.name);
+        tokens.add(token);
+      } else {
+        symbols.add(token);
+      }
+    }
+  }
+
+  public Capture match(String target, Capture variables) {
+    if (pass) return new Capture();
+
+    String source = this.source;
+    for (int index = tokens.size(); index > 0; --index) {
+      Token anchor = tokens.get(index - 1);
+      String value = variables.getOrDefault(anchor.name, "[\\w-.]+");
+      source = anchor.replace(source, value, offset);
+    }
+    String[] segments = VARIABLE.split(source, -1);
+    if (segments[0].equals("")) {
+      source = "(.+)?" + String.join("([\\w-.]+)", segments).substring(9);
+    } else {
+      source = String.join("([\\w-.]+)", segments);
+    }
+
+    target = target.replace("\\/", "__slash__");
+
+    Pattern regexp = Pattern.compile(source, Pattern.CASE_INSENSITIVE);
+    Matcher matcher = regexp.matcher(target);
+    if (!matcher.matches()) return null;
+
+    Capture captures = new Capture();
+    int count = matcher.groupCount();
+    for (int i = 1; i <= count; ++i) {
+      String value = matcher.group(i)
+          .replace("__slash__", "/")
+          .replace("-", "")
+          .replace("_", "")
+          .toLowerCase();
+      Token token = symbols.get(i - 1);
+      if (token.modifier.equals("dot")) {
+        value = value.replace(".", "/");
+      }
+      captures.put(token.name, value);
+    }
+    if (leading != null) captures.greedy.add(leading);
+    return captures;
+  }
+}

--- a/xll/src/main/java/edu/pku/code2graph/xll/LayerPattern.java
+++ b/xll/src/main/java/edu/pku/code2graph/xll/LayerPattern.java
@@ -3,103 +3,69 @@ package edu.pku.code2graph.xll;
 import edu.pku.code2graph.model.Language;
 import edu.pku.code2graph.model.Layer;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.util.*;
 
 public class LayerPattern extends Layer {
-  private final boolean pass;
-  private int offset = 0;
-  private String source;
-  private String leading;
-  private final List<Token> tokens = new ArrayList<>();
+  public static Set<String> patternAttributes = new HashSet<>();
+
+  static {
+    patternAttributes.add("varType");
+    patternAttributes.add("identifier");
+  }
+
+  private final Map<String, IdentifierPattern> matchers = new HashMap<>();
 
   public final List<String> anchors = new ArrayList<>();
-  public final List<Token> symbols = new ArrayList<>();
+  public final List<String> symbols = new ArrayList<>();
 
   public LayerPattern(String identifier, Language language) {
     super(identifier, language);
+    IdentifierPattern matcher = new IdentifierPattern(identifier);
+    matchers.put("identifier", matcher);
+    anchors.addAll(matcher.anchors);
+    for (Token token : matcher.symbols) {
+      symbols.add(token.name);
+    }
+  }
 
-    pass = identifier.equals("**");
-    if (pass) return;
-
-    source =
-        ("**/" + identifier)
-            .replaceAll("\\\\", "\\\\\\\\")
-            .replaceAll("\\.", "\\\\.")
-            .replaceAll("\\^", "\\\\^")
-            .replaceAll("\\$", "\\\\\\$")
-            .replaceAll("\\+", "\\\\+")
-            .replaceAll("\\*\\*/", "(?:.+/)?")
-            .replaceAll("\\*", "\\\\w+")
-            .replaceAll("\\{", "\\\\{");
-
-    Matcher matcher = VARIABLE.matcher(source);
-    while (matcher.find()) {
-      Token token = new Token(matcher);
-      if (token.isGreedy) {
-        leading = token.name;
-        source = source.substring(8);
-        offset = 8;
-      }
-      if (token.isAnchor) {
-        anchors.add(token.name);
-        tokens.add(token);
-      } else {
-        symbols.add(token);
+  @Override
+  public String put(String key, String value) {
+    String result = super.put(key, value);
+    if (matchers == null) return result;
+    if (patternAttributes.contains(key)) {
+      IdentifierPattern matcher = new IdentifierPattern(value);
+      matchers.put(key, matcher);
+      anchors.addAll(matcher.anchors);
+      for (Token token : matcher.symbols) {
+        symbols.add(token.name);
       }
     }
+    return result;
   }
 
   public Capture match(Layer layer, Capture variables) {
-    if (pass) return new Capture();
+    Capture result = new Capture();
 
-    for (String key : attributes.keySet()) {
-      String value = layer.getAttribute(key);
-      if (value == null || !value.equals(attributes.get(key))) {
-        return null;
+    // perform strict matching
+    for (String key : keySet()) {
+      String target = layer.getAttribute(key);
+      if (target == null) return null;
+
+      if (!patternAttributes.contains(key)) {
+        String source = getAttribute(key);
+        if (!source.equals(target)) return null;
       }
     }
 
-    String source = this.source;
-    for (int index = tokens.size(); index > 0; --index) {
-      Token anchor = tokens.get(index - 1);
-      String value = variables.getOrDefault(anchor.name, "[\\w-.]+");
-      source = anchor.replace(source, value, offset);
-    }
-    String[] segments = VARIABLE.split(source, -1);
-    if (segments[0].equals("")) {
-      source = "(.+)?" + String.join("([\\w-.]+)", segments).substring(9);
-    } else {
-      source = String.join("([\\w-.]+)", segments);
+    // perform pattern matching
+    for (String key : matchers.keySet()) {
+      IdentifierPattern matcher = matchers.get(key);
+      String target = layer.get(key);
+      Capture capture = matcher.match(target, variables);
+      if (capture == null) return null;
+      result.merge(capture);
     }
 
-    String target = layer
-        .getIdentifier()
-        .replace("\\/", "__slash__");
-
-    Pattern regexp = Pattern.compile(source, Pattern.CASE_INSENSITIVE);
-    Matcher matcher = regexp.matcher(target);
-    if (!matcher.matches()) return null;
-
-    Capture captures = new Capture();
-    int count = matcher.groupCount();
-    for (int i = 1; i <= count; ++i) {
-      String value = matcher.group(i)
-          .replace("__slash__", "/")
-          .replace("-", "")
-          .replace("_", "")
-          .toLowerCase();
-      Token token = symbols.get(i - 1);
-      if (token.modifier.equals("dot")) {
-        value = value.replace(".", "/");
-      }
-      captures.put(token.name, value);
-    }
-    if (leading != null) captures.greedy.add(leading);
-    return captures;
+    return result;
   }
-
-  public static final Pattern VARIABLE = Pattern.compile("\\(&?(\\w+)(?::(\\w+))?((\\\\\\.){3})?\\)");
 }

--- a/xll/src/main/java/edu/pku/code2graph/xll/Linker.java
+++ b/xll/src/main/java/edu/pku/code2graph/xll/Linker.java
@@ -101,7 +101,13 @@ public class Linker {
 
   public void print() {
     System.out.println(rule.name);
-    System.out.println(links.size());
-    System.out.println(links);
+    System.out.println("links: " + links.size());
+    for (Link link : links) {
+      System.out.println(link);
+    }
+    System.out.println("captures: " + captures.size());
+    for (Capture capture : captures) {
+      System.out.println(capture);
+    }
   }
 }

--- a/xll/src/main/java/edu/pku/code2graph/xll/Linker.java
+++ b/xll/src/main/java/edu/pku/code2graph/xll/Linker.java
@@ -88,10 +88,10 @@ public class Linker {
         // generate results
         for (Capture use : uses.getRight()) {
           for (Capture def : defs.getRight()) {
-            Capture result = new Capture();
-            result.putAll(variables);
-            result.putAll(def);
-            result.putAll(use);
+            Capture result = variables.clone();
+            result.merge(variables);
+            result.merge(def);
+            result.merge(use);
             captures.add(result);
           }
         }

--- a/xll/src/main/java/edu/pku/code2graph/xll/Rule.java
+++ b/xll/src/main/java/edu/pku/code2graph/xll/Rule.java
@@ -19,7 +19,7 @@ public class Rule {
     this.def = def;
     this.use = use;
     this.deps = new ArrayList<>();
-    this.name = "#" + String.valueOf(++index);
+    this.name = "#" + ++index;
     initialize();
   }
 

--- a/xll/src/main/java/edu/pku/code2graph/xll/URIPattern.java
+++ b/xll/src/main/java/edu/pku/code2graph/xll/URIPattern.java
@@ -38,9 +38,7 @@ public class URIPattern extends URILike<LayerPattern> {
   public LayerPattern addLayer(String identifier, Language language) {
     LayerPattern layer = new LayerPattern(identifier, language);
     layers.add(layer);
-    for (Token token : layer.symbols) {
-      symbols.add(token.name);
-    }
+    symbols.addAll(layer.symbols);
     anchors.addAll(layer.anchors);
     return layer;
   }

--- a/xll/src/main/java/edu/pku/code2graph/xll/pattern/AttributePattern.java
+++ b/xll/src/main/java/edu/pku/code2graph/xll/pattern/AttributePattern.java
@@ -1,0 +1,7 @@
+package edu.pku.code2graph.xll.pattern;
+
+import edu.pku.code2graph.xll.Capture;
+
+public interface AttributePattern {
+  Capture match(String target, Capture variables);
+}

--- a/xll/src/main/java/edu/pku/code2graph/xll/pattern/IdentifierPattern.java
+++ b/xll/src/main/java/edu/pku/code2graph/xll/pattern/IdentifierPattern.java
@@ -1,14 +1,14 @@
-package edu.pku.code2graph.xll;
+package edu.pku.code2graph.xll.pattern;
 
-import edu.pku.code2graph.model.Language;
-import edu.pku.code2graph.model.Layer;
+import edu.pku.code2graph.xll.Capture;
+import edu.pku.code2graph.xll.Token;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class IdentifierPattern {
+public class IdentifierPattern implements AttributePattern {
   public static final Pattern VARIABLE = Pattern.compile("\\(&?(\\w+)(?::(\\w+))?((\\\\\\.){3})?\\)");
 
   private final boolean pass;

--- a/xll/src/main/java/edu/pku/code2graph/xll/pattern/LanguagePattern.java
+++ b/xll/src/main/java/edu/pku/code2graph/xll/pattern/LanguagePattern.java
@@ -1,0 +1,18 @@
+package edu.pku.code2graph.xll.pattern;
+
+import edu.pku.code2graph.xll.Capture;
+
+public class LanguagePattern implements AttributePattern {
+  private final String source;
+
+  public LanguagePattern(String source) {
+    this.source = source;
+  }
+
+  public Capture match(String target, Capture variables) {
+    if (source.equals("ANY")) return new Capture();
+    if (target.equals("ANY")) return new Capture();
+    if (source.equals(target)) return new Capture();
+    return null;
+  }
+}

--- a/xll/src/test/java/LinkerTest.java
+++ b/xll/src/test/java/LinkerTest.java
@@ -91,7 +91,6 @@ public class LinkerTest {
     for (Capture variables : linker1.captures) {
       linker2.link(variables);
     }
-    linker2.link();
     linker2.print();
   }
 

--- a/xll/src/test/java/LinkerTest.java
+++ b/xll/src/test/java/LinkerTest.java
@@ -97,19 +97,40 @@ public class LinkerTest {
   @Test
   public void matchTest4() {
     URITree tree = new URITree();
-    tree.add("def://foo/baz/qux.html");
-    tree.add("use://source.java//events/return//baz\\/qux");
+    tree.add("def://BlogController.java//showPost/return//blog\\/show");
+    tree.add("def://BlogController.java//showPost/model.addAttribute//categories");
+    tree.add("use://root/blog/show.html");
+    tree.add("use://root/blog/show.html//html/body/form/select/option/data-th-each//${categories}");
 
-    URIPattern def = new URIPattern(false, "(htmlFile...).html");
+    URIPattern def, use;
 
-    URIPattern use = new URIPattern(true, "*.java");
+    // rule 1
+    def = new URIPattern(false, "(htmlFile...).html");
+
+    use = new URIPattern(true, "(javaFile).java");
     use.addLayer("(functionName)/return", Language.JAVA);
     use.addLayer("(htmlFile)");
 
-    Linker linker = new Linker(tree, def, use);
-    linker.link();
-    System.out.println(linker.links);
-    System.out.println(linker.captures);
+    Linker linker1 = new Linker(tree, def, use);
+    linker1.link();
+    System.out.println(linker1.links);
+    System.out.println(linker1.captures);
+
+    // rule 2
+    def = new URIPattern(false, "(&javaFile).java");
+    def.addLayer("(&functionName)/(&modelName).addAttribute", Language.JAVA);
+    def.addLayer("(name)");
+
+    use = new URIPattern(true, "(&htmlFile).html");
+    use.addLayer("**", Language.HTML);
+    use.addLayer("${(name)}");
+
+    Linker linker2 = new Linker(tree, def, use);
+    for (Capture variables : linker1.captures) {
+      linker2.link(variables);
+    }
+    System.out.println(linker2.links);
+    System.out.println(linker2.captures);
   }
 
   @Test


### PR DESCRIPTION
比想象中复杂好多……

基本功能已经实现了，全部改动如下：

- layer 直接变成一个 hash map，其中 identifier 和 language 都是它的特殊属性
- 只是内部数据结构修改，之前的各种 getIdentifier, setLanguage 等等方法都还在
- attribute 匹配会有两种模式：
  - pattern mode：即 identifier 目前表现出的行为，目前有 identifier 和 varType 采用此模式
  - strict mode：严格匹配，直接判断字符串相等，目前其他 attribute 均采用此模式

---

待解决的问题：

- 理论上 identifier 与 varType 的行为也不完全一致，varType 可能不需要在前面加 `**/`，因此需要有三种模式
- 经测试这个 PR 在部分数据出现了 ambiguous xll，在进一步的测试中发现在在这个 PR 之前行为已经不正确了，对比下面两个 commit：
  - 1caa4b941eaadf95ccc725c7cace8aa712cf00b9
  - 1e490b5d75c21cc88ff9afbd0d8843b806b508f0 (main)
  - 后者召回率似乎偏低，目前正在研究问题的成因，大概率是我这边的问题

